### PR TITLE
Add new connection pool interface for JdbcCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/ConnectionClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/ConnectionClientPool.java
@@ -1,0 +1,9 @@
+package org.apache.iceberg.jdbc;
+
+import java.io.Closeable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.apache.iceberg.ClientPool;
+
+public interface ConnectionClientPool extends Closeable, ClientPool<Connection, SQLException> {
+}

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -83,10 +83,10 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
   private String catalogName = "jdbc";
   private String warehouseLocation;
   private Object conf;
-  private JdbcClientPool connections;
+  private ConnectionClientPool connections;
   private Map<String, String> catalogProperties;
   private final Function<Map<String, String>, FileIO> ioBuilder;
-  private final Function<Map<String, String>, JdbcClientPool> clientPoolBuilder;
+  private final Function<Map<String, String>, ConnectionClientPool> clientPoolBuilder;
   private boolean initializeCatalogTables;
   private CloseableGroup closeableGroup;
   private JdbcUtil.SchemaVersion schemaVersion = JdbcUtil.SchemaVersion.V0;
@@ -97,7 +97,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
 
   public JdbcCatalog(
       Function<Map<String, String>, FileIO> ioBuilder,
-      Function<Map<String, String>, JdbcClientPool> clientPoolBuilder,
+      Function<Map<String, String>, ConnectionClientPool> clientPoolBuilder,
       boolean initializeCatalogTables) {
     this.ioBuilder = ioBuilder;
     this.clientPoolBuilder = clientPoolBuilder;
@@ -701,7 +701,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
   }
 
   @VisibleForTesting
-  JdbcClientPool connectionPool() {
+  ConnectionClientPool connectionPool() {
     return connections;
   }
 

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.ClientPoolImpl;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
-public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
+public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> implements ConnectionClientPool {
 
   /**
    * The following are common retryable SQLSTATEs error codes which are generic across vendors.

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -47,12 +47,12 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   private final String catalogName;
   private final TableIdentifier tableIdentifier;
   private final FileIO fileIO;
-  private final JdbcClientPool connections;
+  private final ConnectionClientPool connections;
   private final Map<String, String> catalogProperties;
   private final JdbcUtil.SchemaVersion schemaVersion;
 
   protected JdbcTableOperations(
-      JdbcClientPool dbConnPool,
+      ConnectionClientPool dbConnPool,
       FileIO fileIO,
       String catalogName,
       TableIdentifier tableIdentifier,

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -526,7 +526,7 @@ final class JdbcUtil {
   private static int update(
       boolean isTable,
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier identifier,
       String newMetadataLocation,
@@ -555,7 +555,7 @@ final class JdbcUtil {
 
   static int updateTable(
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier tableIdentifier,
       String newMetadataLocation,
@@ -572,7 +572,7 @@ final class JdbcUtil {
   }
 
   static int updateView(
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier viewIdentifier,
       String newMetadataLocation,
@@ -591,7 +591,7 @@ final class JdbcUtil {
   private static Map<String, String> tableOrView(
       boolean isTable,
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier identifier)
       throws SQLException, InterruptedException {
@@ -630,7 +630,7 @@ final class JdbcUtil {
 
   static Map<String, String> loadTable(
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier identifier)
       throws SQLException, InterruptedException {
@@ -639,7 +639,7 @@ final class JdbcUtil {
 
   static Map<String, String> loadView(
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       TableIdentifier identifier)
       throws SQLException, InterruptedException {
@@ -649,7 +649,7 @@ final class JdbcUtil {
   private static int doCommitCreate(
       boolean isTable,
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       Namespace namespace,
       TableIdentifier identifier,
@@ -677,7 +677,7 @@ final class JdbcUtil {
 
   static int doCommitCreateTable(
       SchemaVersion schemaVersion,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       Namespace namespace,
       TableIdentifier tableIdentifier,
@@ -694,7 +694,7 @@ final class JdbcUtil {
   }
 
   static int doCommitCreateView(
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       String catalogName,
       Namespace namespace,
       TableIdentifier viewIdentifier,
@@ -711,7 +711,7 @@ final class JdbcUtil {
   }
 
   static boolean viewExists(
-      String catalogName, JdbcClientPool connections, TableIdentifier viewIdentifier) {
+      String catalogName, ConnectionClientPool connections, TableIdentifier viewIdentifier) {
     return exists(
         connections,
         GET_VIEW_SQL,
@@ -723,7 +723,7 @@ final class JdbcUtil {
   static boolean tableExists(
       SchemaVersion schemaVersion,
       String catalogName,
-      JdbcClientPool connections,
+      ConnectionClientPool connections,
       TableIdentifier tableIdentifier) {
     return exists(
         connections,
@@ -782,7 +782,7 @@ final class JdbcUtil {
   }
 
   static boolean namespaceExists(
-      String catalogName, JdbcClientPool connections, Namespace namespace) {
+      String catalogName, ConnectionClientPool connections, Namespace namespace) {
 
     String namespaceEquals = JdbcUtil.namespaceToString(namespace);
     // when namespace has sub-namespace then additionally checking it with LIKE statement.
@@ -802,7 +802,7 @@ final class JdbcUtil {
   }
 
   @SuppressWarnings("checkstyle:NestedTryDepth")
-  private static boolean exists(JdbcClientPool connections, String sql, String... args) {
+  private static boolean exists(ConnectionClientPool connections, String sql, String... args) {
     try {
       return connections.run(
           conn -> {

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcViewOperations.java
@@ -48,11 +48,11 @@ public class JdbcViewOperations extends BaseViewOperations {
   private final String catalogName;
   private final TableIdentifier viewIdentifier;
   private final FileIO fileIO;
-  private final JdbcClientPool connections;
+  private final ConnectionClientPool connections;
   private final Map<String, String> catalogProperties;
 
   protected JdbcViewOperations(
-      JdbcClientPool dbConnPool,
+      ConnectionClientPool dbConnPool,
       FileIO fileIO,
       String catalogName,
       TableIdentifier viewIdentifier,

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -217,7 +217,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     JdbcCatalog jdbcCatalog = new JdbcCatalog();
     jdbcCatalog.setConf(conf);
     jdbcCatalog.initialize("test_catalog_with_retryable_status_codes", properties);
-    JdbcClientPool jdbcClientPool = jdbcCatalog.connectionPool();
+    JdbcClientPool jdbcClientPool = (JdbcClientPool) jdbcCatalog.connectionPool();
     List<SQLException> expectedRetryableExceptions =
         Lists.newArrayList(
             new SQLException("operator_intervention", "57000"),
@@ -236,7 +236,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     // Test the same retryable status codes but with spaces in the configuration
     properties.put(JdbcUtil.RETRYABLE_STATUS_CODES, "57000, 57P03, 57P04");
     jdbcCatalog.initialize("test_catalog_with_retryable_status_codes_with_spaces", properties);
-    JdbcClientPool updatedClientPool = jdbcCatalog.connectionPool();
+    JdbcClientPool updatedClientPool = (JdbcClientPool) jdbcCatalog.connectionPool();
     expectedRetryableExceptions.forEach(
         exception -> {
           assertThat(updatedClientPool.isConnectionException(exception))
@@ -254,7 +254,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     JdbcCatalog jdbcCatalog = new JdbcCatalog();
     jdbcCatalog.setConf(conf);
     jdbcCatalog.initialize("test_catalog_with_retryable_status_codes", properties);
-    JdbcClientPool jdbcClientPool = jdbcCatalog.connectionPool();
+    JdbcClientPool jdbcClientPool = (JdbcClientPool) jdbcCatalog.connectionPool();
     assertThat(
             jdbcClientPool.isConnectionException(
                 new SQLNonTransientConnectionException("Failed to authenticate")))


### PR DESCRIPTION
Allow creating a JdbcCatalog with a custom connection pool (without the need of passing a uri).

This change should be backwards compatible since I'm only changing the method signatures from accepting an implementation class to an interface (new `ConnectionClientPool`) which JdbcClientPool implements.

The custom connection pool can be passed via the old `clientPoolBuilder` argument in one of the JdbcCatalog constructors.